### PR TITLE
Remove unused 'custom' capabilities, set valid driver class

### DIFF
--- a/app.json
+++ b/app.json
@@ -40,8 +40,8 @@
 				"large": "./drivers/chromecast/assets/images/large.jpg",
 				"small": "./drivers/chromecast/assets/images/small.jpg"
 			},
-			"class": "videoplayer",
-			"capabilities": [ "play", "pause", "stop" ],
+			"class": "other",
+			"capabilities": [ ],
 			"pair": [
 				{
 					"id": "list_chromecasts",


### PR DESCRIPTION
This patch should fix the invalid_device error present since 0.9.1 due
to some api changes concerning custom capabilities.